### PR TITLE
docs: add changelog, upgrade guide, and README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `filament-editorjs` will be documented in this file.
 
+## 2.0.0 - 2025-09-01
+### Added
+- Livewire-based file uploads for the Editor.js field using Filament's `HasFileAttachments`.
+- Image upload responses now include both the file URL and media ID.
+
+### Changed
+- Requires `filament/filament` `^3.3` and `filament/spatie-laravel-media-library-plugin`.
+- `ModelHasEditorJsComponent` now saves `TemporaryUploadedFile` instances via `editJsSaveImageFromTempFile`.
+- Improved Editor.js client script with file type and size validation.
+
+### Removed
+- `HasImageUploadEndpoints` trait and `FilamentEditorJsController`; custom upload routes are no longer needed.
+
 ## 1.0.0 - 202X-XX-XX
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -180,33 +180,13 @@ public static function form(Form $form): Form
 }
 ```
 
-#### Configuring axios to successfully upload images
-This package comes with some javascript code that will upload the image to the server. 
-Usually you would have something like this in your `boostrap.js` file:
+#### Handling image uploads
 
-```js
-import axios from 'axios';
-
-window.axios = axios;
-
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-```
-
-This piece of javascript code, as far as I know, allows frontend code to upload files to the Laravel backend. 
-Something to do with CSRF protection.
-
-Because of this, you will need to define the following Filament Render hook in your application's `AppServiceProvider`;
-
-```php
-FilamentView::registerRenderHook(
-    PanelsRenderHook::HEAD_END,
-    fn(): string => Blade::render('@vite(\'resources/js/app.js\')'),
-);
-```
-
-> This also assumes that you have set up your project's vite configuration correctly.
-
-> We're using the app.js file cause the bootstrap.js file is simply included in the app.js file. 
+Starting with version 2, `EditorjsTextField` relies on Filament's
+`HasFileAttachments` to manage image uploads through Livewire. This means
+uploads work out of the box—no custom endpoints or Axios configuration are
+required. The component will automatically upload the image and resolve the
+stored media's preview URL and ID.
 
 ## Testing
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,15 @@
+# Upgrade Guide
+
+## Upgrading from 1.x to 2.0
+
+1. Update your composer dependencies:
+   - Require `filament/filament` version `^3.3`.
+   - Replace direct usage of `spatie/laravel-medialibrary` with `filament/spatie-laravel-media-library-plugin`.
+2. Remove the image upload routes and controller:
+   - The `FilamentEditorJsController` and its routes have been deleted.
+   - The `HasImageUploadEndpoints` trait and related methods such as `setDefaultUploadUrl()` are no longer used.
+3. File uploads are now handled through Livewire's `HasFileAttachments`:
+   - Ensure your models still use the `ModelHasEditorJsComponent` trait and register the necessary media collections and conversions.
+   - If you previously overrode `editorJsSaveImageFromRequest`, rename your method to `editJsSaveImageFromTempFile(TemporaryUploadedFile $file)`.
+4. The upload response now returns both the image URL and media ID. Update any code that processes uploaded image data accordingly.
+


### PR DESCRIPTION
## Summary
- document 2.0.0 changes and removals in CHANGELOG
- add an upgrade guide for migrating from 1.x
- update README to describe Livewire-based uploads

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/bin/pest not found)*
- `composer format` *(fails: vendor/bin/pint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f8ab16848331a54292690d142e70